### PR TITLE
Regra Completa de Anos Bissextos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin/
+*.prefs

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /bin/
-*.prefs

--- a/CursoJavaExercicios/src/controle/Exercicio2.java
+++ b/CursoJavaExercicios/src/controle/Exercicio2.java
@@ -12,9 +12,20 @@ public class Exercicio2 {
 		System.out.println("Digite o ano: ");
 		int ano = scanner.nextInt();
 
-		int bissexto = ano % 4;
+		/**
+		 * 1. De 4 em 4 anos é ano bissexto.
+		 * 2. De 100 em 100 anos não é ano bissexto.
+         * 3. De 400 em 400 anos é ano bissexto.
+         * 4. Prevalecem as últimas regras sobre as primeiras.
+         * 
+         * https://pt.wikipedia.org/wiki/Ano_bissexto
+		 */
+		
+		int bissextoTest1 = ano % 4;
+		int bissextoTest2 = ano % 100;
+		int bissextoTest3 = ano % 400;
 
-		if (bissexto == 0) {
+		if (bissextoTest3 == 0 || ( bissextoTest1 == 0 && bissextoTest2 != 0 ) ) {
 			System.out.println(ano + " é um ano bissexto");
 		} else {
 			System.out.println(ano + " não é um ano bissexto");

--- a/CursoJavaExercicios/src/controle/Exercicio2.java
+++ b/CursoJavaExercicios/src/controle/Exercicio2.java
@@ -12,9 +12,13 @@ public class Exercicio2 {
 		System.out.println("Digite o ano: ");
 		int ano = scanner.nextInt();
 
-		int bissexto = ano % 4;
+		int bissextoTest1 = ano % 4;
 
-		if (bissexto == 0) {
+		int bissextoTest2 = ano % 100;
+
+		int bissextoTest3 = ano % 400;
+
+		if (bissextoTest3 == 0 || (bissextoTest1 == 0 && bissextoTest2 != 0)) {
 			System.out.println(ano + " é um ano bissexto");
 		} else {
 			System.out.println(ano + " não é um ano bissexto");

--- a/CursoJavaExercicios/src/controle/Exercicio2.java
+++ b/CursoJavaExercicios/src/controle/Exercicio2.java
@@ -12,20 +12,9 @@ public class Exercicio2 {
 		System.out.println("Digite o ano: ");
 		int ano = scanner.nextInt();
 
-		/**
-		 * 1. De 4 em 4 anos é ano bissexto.
-		 * 2. De 100 em 100 anos não é ano bissexto.
-         * 3. De 400 em 400 anos é ano bissexto.
-         * 4. Prevalecem as últimas regras sobre as primeiras.
-         * 
-         * https://pt.wikipedia.org/wiki/Ano_bissexto
-		 */
-		
-		int bissextoTest1 = ano % 4;
-		int bissextoTest2 = ano % 100;
-		int bissextoTest3 = ano % 400;
+		int bissexto = ano % 4;
 
-		if (bissextoTest3 == 0 || ( bissextoTest1 == 0 && bissextoTest2 != 0 ) ) {
+		if (bissexto == 0) {
 			System.out.println(ano + " é um ano bissexto");
 		} else {
 			System.out.println(ano + " não é um ano bissexto");


### PR DESCRIPTION
Inserida a regra completa de anos bissextos, conforme [Wikipedia](https://pt.wikipedia.org/wiki/Ano_bissexto):

1. De 4 em 4 anos é ano bissexto.
2. De 100 em 100 anos não é ano bissexto.
3. De 400 em 400 anos é ano bissexto.
4. Prevalecem as últimas regras sobre as primeiras.